### PR TITLE
Add 47-prefix to recipient of outgoing messages

### DIFF
--- a/app/models/sms_broker/outgoing_message.rb
+++ b/app/models/sms_broker/outgoing_message.rb
@@ -26,6 +26,22 @@ module SmsBroker
       self.delivery_attempts ||= 0
     end
 
+    ##
+    # Prepend 8 digit phone numbers with Norwegian country code.
+    #
+    # PSWinCom / LinkMobility expects phone numbers to be at least 9 digits,
+    # and thus Norwegian numbers should be prefixed with 47.
+    #
+    def recipient=(phone_number)
+      recipient = if phone_number =~ /\A(4|9)\d{7}\Z/
+                    '47' + phone_number
+                  else
+                    phone_number
+                  end
+
+      write_attribute(:recipient, recipient)
+    end
+
     def self.register_after_create_hook(hook)
       unless @@after_create_hooks.include?(hook)
         @@after_create_hooks << hook

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -38,6 +38,38 @@ module SmsBroker
       end
     end
 
+    describe "#recipient=" do
+      context "8 digit phone number" do
+        let(:phone) { "98765432" }
+
+        it 'adds norwegian country code as prefix' do
+          subject.recipient = phone
+
+          expect(subject.recipient).to eq "47#{phone}"
+        end
+      end
+
+      context "more than 8 digit phone number" do
+        let(:phone) { "987654321" }
+
+        it 'leaves phone number unmodified' do
+          subject.recipient = phone
+
+          expect(subject.recipient).to eq phone
+        end
+      end
+
+      context "already prefixed Norwgian phone number" do
+        let(:phone) { "4798765432" }
+
+        it 'leaves phone number unmodified' do
+          subject.recipient = phone
+
+          expect(subject.recipient).to eq phone
+        end
+      end
+    end
+
     describe ".build_from_incoming" do
       it "uses incoming message to set up new object" do
         incoming_message = build :incoming_message, id: 1


### PR DESCRIPTION
Works around a problem where outgoing messages are lacking
the proper country prefix when they are created.