### PR TITLE
Remove strict dependency from rails 4

### DIFF
--- a/sms_broker.gemspec
+++ b/sms_broker.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   #s.test_files = Dir["test/**/*"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "rails", "~> 4"
+  s.add_dependency "rails", ">= 4"
   s.add_dependency "delayed_job", "~> 4"
   s.add_dependency "pswincom", "~>0.1.8"
 


### PR DESCRIPTION
## Why

To support Rails 5